### PR TITLE
Removed MaterialApp from widget tree

### DIFF
--- a/lib/src/flutter_no_internet_widget.dart
+++ b/lib/src/flutter_no_internet_widget.dart
@@ -68,41 +68,40 @@ class InternetWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      home: ResponsiveSizer(
-        builder: (context, orientation, screenType) {
-          return BlocProvider<InternetCubit>(
-            create: (context) => InternetCubit(
-              urlLookup: lookupUrl,
-            ),
-            child: Scaffold(
-              body: Builder(
-                builder: (_) {
-                  return BlocBuilder<InternetCubit, InternetState>(
-                    builder: (_, state) {
-                      if (state.cubitStatus == CubitStatus.busy) {
-                        if (loadingWidget != null) {
-                          return loadingWidget!;
-                        }
-                        return const Center(
-                          child: CircularProgressIndicator(),
-                        );
-                      }
-                      return SizedBox(
-                        width: width ?? 100.0.w,
-                        height: height ?? 100.0.h,
-                        child: state.internetStatus == InternetStatus.connected
-                            ? _getOnlineWidget()
-                            : _getOfflineWidget(),
-                      );
-                    },
-                  );
-                },
+    return ResponsiveSizer(
+      builder: (context, orientation, screenType) {
+        return BlocProvider<InternetCubit>(
+          create: (context) =>
+              InternetCubit(
+                urlLookup: lookupUrl,
               ),
+          child: Scaffold(
+            body: Builder(
+              builder: (_) {
+                return BlocBuilder<InternetCubit, InternetState>(
+                  builder: (_, state) {
+                    if (state.cubitStatus == CubitStatus.busy) {
+                      if (loadingWidget != null) {
+                        return loadingWidget!;
+                      }
+                      return const Center(
+                        child: CircularProgressIndicator(),
+                      );
+                    }
+                    return SizedBox(
+                      width: width ?? 100.0.w,
+                      height: height ?? 100.0.h,
+                      child: state.internetStatus == InternetStatus.connected
+                          ? _getOnlineWidget()
+                          : _getOfflineWidget(),
+                    );
+                  },
+                );
+              },
             ),
-          );
-        },
-      ),
+          ),
+        );
+      },
     );
   }
 


### PR DESCRIPTION
Hi,

is there a reason why the widget includes a `MaterialApp`? It's causing weird issues on my setup (`Could not find a generator for route RouteSettings("/xxx", null) in the _WidgetsAppState`) and I don't think it's really useful, is it?

Thanks,
Maurizio