### PR TITLE
Added one parameter resizeToAvoidBottomInset

### DIFF
--- a/lib/src/flutter_no_internet_widget.dart
+++ b/lib/src/flutter_no_internet_widget.dart
@@ -42,6 +42,7 @@ class InternetWidget extends StatelessWidget {
     this.whenOnline,
     this.connectivity,
     this.offline,
+    this.resizeToAvoidBottomInset,
   }) : super(key: key);
 
   ///Width of the widget
@@ -72,6 +73,9 @@ class InternetWidget extends StatelessWidget {
   ///Widget to be displayed when there is no internet connection
   final OfflineWidgetType? offline;
 
+  ///Added resizeToAvoidBottomInset
+  final bool? resizeToAvoidBottomInset;
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -84,6 +88,7 @@ class InternetWidget extends StatelessWidget {
               urlLookup: lookupUrl,
             ),
             child: Scaffold(
+              resizeToAvoidBottomInset: resizeToAvoidBottomInset ?? true,
               body: Builder(
                 builder: (_) {
                   return BlocBuilder<InternetCubit, InternetState>(


### PR DESCRIPTION
Added one parameter resizeToAvoidBottomInset because No Internet screen/widget is parent screen/widget of many screen/widget and resizeToAvoidBottomInset property is used in most upper parent's scaffold 